### PR TITLE
feat: adding terraform to spinup and tear down cluster

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,14 +1,38 @@
+#dependencies
 node_modules
-dist
-npm-debug.log
+
+
+# Environment and secrets
 .env
 .env.local
 .env.*.local
+*.tfvars
+
+# Git 
 .git
 .gitignore
+
+# CI
+.github/
+
+
+# MISC
+dist
+npm-debug.log
 README.md
 .vscode
 .DS_Store
 *.md
 coverage
 .nyc_output
+
+# Docker itself
+Dockerfile
+.dockerignore
+
+#Terraform
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.backup
+**/terraform.tfvars
+

--- a/.github/workflows/spin-up.yaml
+++ b/.github/workflows/spin-up.yaml
@@ -1,0 +1,70 @@
+# Spins up the mike-dev-aks cluster
+
+name: Spin up
+
+on:
+  workflow_dispatch:
+
+jobs:
+  terraform:
+    name: Terraform Apply
+    runs-on: ubuntu-latest
+
+    env:
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup Terraform
+          uses: hashicorp/setup-terraform@v3
+
+        - name: Terraform Init
+          working-directory: terraform
+          run: terraform init
+
+        - name: Terraform Apply
+          working-directory: terraform
+          run: terraform apply -auto-approve
+
+  deploy:
+    name: Deploy to AKS
+    runs-on: ubuntu-latest
+    needs: terraform # waits for the cluster to exist
+
+    steps:
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: >
+            {
+              "clienId": "${{ secrets.AZURE_CLIENT_ID }}"
+              "clientSecret": "${{ secrets.AZURE_CLIENT_SECRET }}"
+              "subscriptionId": "${{ secrets.AZURE_SUBSCRIPTION_ID }}"
+              "tenantId": "${{ secrets.AZURE_TENANT_ID }}"
+            }
+
+      - name: get AKS Credentials
+        run: az aks get-credentials --resource-group mike-dev-rg --name mike-dev-aks
+
+      - name: Push Image to ACR
+        run: |
+          az acr login --name magikrambo --resource-group mike-dev-rg
+          docker build -t magikrambo.azurecr.io/oura-health-app:latest
+          docker push magikrambo.azurecr.io/oura-health-app:latest
+
+      - name: Create Kubernetes Secret
+        run: |
+          kubectl create secret generic oura-secrets \
+             --from-literal=OURA_CLIENT_ID=${{ secrets.OURA_CLIENT_ID }} \
+             --from-literal=OURA_CLIENT_SECRET=${{ secrets.OURA_CLIENT_SECRET }} \
+             --from-literal=OURA_REDIRECT_URI=${{ secrets.OURA_REDIRECT_URI }} \
+             --from-literal=OURA_SCOPE=${{ secrets.OURA_SCOPE }} \
+             --dry-run=client -o yaml | kuebctl aply -f -
+
+      - name: Apply Kubernetes Manifests
+        run: kubectl apply -f k8s-deployment.yaml

--- a/.github/workflows/tear-down.yaml
+++ b/.github/workflows/tear-down.yaml
@@ -1,0 +1,32 @@
+#Workflow to tear down the cluster to save money on usage
+
+name: Tear Down
+
+on:
+  workflow_dispatch:
+
+jobs:
+  destroy:
+    name: Terraform Destory
+    runs-on: ubuntu-latest
+
+    env:
+      ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup Terraform
+          uses: hashicorp/setup-terraform@v3
+
+        - name: Terraform Init
+          working-directory: terraform
+          run: terraform init
+
+        - name: Terraform Destroy
+          working-directory: terraform
+          run: terraform destory -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .env
 node_modules/
+
+
+#Terraform
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.backup
+**/terraform.tfvars

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.117.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:j6wnjpHfBcQC4xd3ZYquaIPIIR46xJQs7rxwPdSOZos=",
+    "zh:0c513676836e3c50d004ece7d2624a8aff6faac14b833b96feeac2e4bc2c1c12",
+    "zh:50ea01ada95bae2f187db9e926e463f45d860767a85ebc59160414e00e76c35d",
+    "zh:52c2a9edacc06b3f72153f5ef6daca0761c6292158815961fe37f60bc576a3d7",
+    "zh:618eed2a06b19b1a025b45b05891846d570a6a1cca4d23f4942f5a99e1f747ae",
+    "zh:61cde5d3165d7e5ec311d5d89486819cd605c1b2d54611b5c97bd4e97dba2762",
+    "zh:6a873358d5031fc222f5e05f029d1237f3dce8345c767665f393283dfa2627f6",
+    "zh:afdd80064b2a04da311856feb4ed45f77ff4df6c356e8c2b10afb51fe7e61c70",
+    "zh:b09113df7e0e8c8959539bd22bae6c39faeb269ba3c4cd948e742f5cf58c35fb",
+    "zh:d340db7973109761cfc27d52aa02560363337c908b2c99b3628adc5a70a99d5b",
+    "zh:d5a577226ebc8c65e8f19384878a86acc4b51ede4b4a82d37c3b331b0efcd4a7",
+    "zh:e2962b147f9e71732df8dbc74940c10d20906f3c003cbfaa1eb9fabbf601a9f0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,35 @@
+resource "azurerm_resource_group" "main" {
+  name     = var.resource_group_name
+  location = var.location
+}
+resource "azurerm_kubernetes_cluster" "main" {
+  name                = var.cluster_name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  dns_prefix          = "mike-dev"
+  oidc_issuer_enabled = true # <-- add this line
+
+  default_node_pool {
+    name       = "default"
+    node_count = 1
+    vm_size    = "Standard_B2s"
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+}
+resource "azurerm_container_registry" "acr" {
+  name                = "magikrambo"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Basic"
+  admin_enabled       = false
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  principal_id                     = azurerm_kubernetes_cluster.main.kubelet_identity[0].object_id
+  role_definition_name             = "AcrPull"
+  scope                            = azurerm_container_registry.acr.id
+  skip_service_principal_aad_check = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "cluster_name" {
+  value = azurerm_kubernetes_cluster.main.name
+}
+
+output "get_credentials_command" {
+  description = "Run this after apply to configure kubectl"
+  value       = "az aks get-credentials --resource-group ${var.resource_group_name} --name ${var.cluster_name}"
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,19 @@
+variable "resource_group_name" {
+  description = "Resource group for the AKS cluster"
+  default     = "mike-dev-rg"
+}
+
+variable "location" {
+  description = "Azure region"
+  default     = "East US"
+}
+
+variable "cluster_name" {
+  description = "Name of the AKS cluster"
+  default     = "mike-dev-aks"
+}
+
+variable "acr_resource_group_name" {
+  description = "Resource group that contains your ACR (magikrambo). Defaults to resource_group_name if left blank."
+  default     = ""
+}


### PR DESCRIPTION
This pull request introduces infrastructure-as-code and CI/CD automation for deploying and managing an Azure Kubernetes Service (AKS) cluster and associated resources using Terraform and GitHub Actions. The main changes include adding Terraform configuration files for resource provisioning, new GitHub Actions workflows for cluster spin-up and tear-down, and updates to `.dockerignore` for improved container build hygiene.

**Infrastructure provisioning with Terraform:**

- Added Terraform configuration files (`main.tf`, `variables.tf`, `outputs.tf`, `providers.tf`, `.terraform.lock.hcl`) to provision an Azure resource group, AKS cluster, and Azure Container Registry (ACR), along with role assignments for secure image pulling. These files also define key variables and outputs to streamline usage. [[1]](diffhunk://#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028R1-R35) [[2]](diffhunk://#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4R1-R19) [[3]](diffhunk://#diff-39c11374cc25633f69e49ef1485fa8d4dfd4c33cde3027c8c20a2b84346ebf7cR1-R8) [[4]](diffhunk://#diff-832814fa1c0667ba9deaf8d383b5c47d12158b43b25f78eb1363418b0e83cc46R1-R12) [[5]](diffhunk://#diff-845d0f38d4ba0c7d301f2a289b3d7304a7298455f93833c345fe398654b095baR1-R22)

**CI/CD automation with GitHub Actions:**

- Introduced a `spin-up.yaml` workflow to automate AKS cluster creation, Docker image build and push, and deployment to Kubernetes, integrating with Terraform and Azure authentication.
- Added a `tear-down.yaml` workflow to automate destruction of the AKS cluster and associated resources to optimize cost.

**Container build and environment hygiene:**

- Updated `.dockerignore` to exclude dependencies, environment files, CI/CD configs, Terraform state, and other unnecessary files from Docker build context, reducing image size and risk of leaking sensitive information.